### PR TITLE
fix theme directory

### DIFF
--- a/theme.conf
+++ b/theme.conf
@@ -3,17 +3,17 @@
 #
 
 # Load banner and fit to screen
-banner themes/refind-ambience/background.png
+banner themes/refind-eve-v/background.png
 banner_scale fillscreen
 
 # Load icons
 big_icon_size 256
 small_icon_size 64
-icons_dir themes/refind-ambience/icons
+icons_dir themes/refind-eve-v/icons
 
 # Load selection background
-selection_big themes/refind-ambience/selection_big.png
-selection_small themes/refind-ambience/selection_small.png
+selection_big themes/refind-eve-v/selection_big.png
+selection_small themes/refind-eve-v/selection_small.png
 
 # Hide everything
 hideui singleuser,hints,arrows,label,badges


### PR DESCRIPTION
The files when cloning the repo are located in `themes/refind-eve-v/` but the `theme.conf` lists `themes/refind-ambience/` as the directory, resulting in rEFInd not being able to find the required files on boot.